### PR TITLE
Adds save timestamped image and last person attribute

### DIFF
--- a/custom_components/sighthound/image_processing.py
+++ b/custom_components/sighthound/image_processing.py
@@ -14,6 +14,7 @@ import simplehound.core as hound
 import logging
 import voluptuous as vol
 
+import homeassistant.util.dt as dt_util
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.image_processing import (
@@ -27,19 +28,23 @@ from homeassistant.components.image_processing import (
     CONF_NAME,
     draw_box,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY, CONF_MODE
+from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY, CONF_FILE_PATH, CONF_MODE
 
 _LOGGER = logging.getLogger(__name__)
 
 EVENT_FACE_DETECTED = "image_processing.face_detected"
 EVENT_PERSON_DETECTED = "image_processing.person_detected"
+EVENT_FILE_SAVED = "image_processing.file_saved"
 
 ATTR_BOUNDING_BOX = "bounding_box"
 ATTR_PEOPLE = "people"
 CONF_ACCOUNT_TYPE = "account_type"
 CONF_SAVE_FILE_FOLDER = "save_file_folder"
+CONF_SAVE_TIMESTAMPTED_FILE = "save_timestamped_file"
 DEV = "dev"
 PROD = "prod"
+
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 RED = (255, 0, 0)
 
@@ -50,6 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_ACCOUNT_TYPE, default=DEV): vol.In([DEV, PROD]),
         vol.Optional(CONF_SAVE_FILE_FOLDER): cv.isdir,
+        vol.Optional(CONF_SAVE_TIMESTAMPTED_FILE, default=False): cv.boolean,
     }
 )
 
@@ -66,6 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             config.get(CONF_API_KEY),
             config.get(CONF_ACCOUNT_TYPE),
             save_file_folder,
+            config.get(CONF_SAVE_TIMESTAMPTED_FILE),
             camera.get(CONF_ENTITY_ID),
             camera.get(CONF_NAME),
         )
@@ -76,7 +83,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class SighthoundEntity(ImageProcessingEntity):
     """Create a sighthound entity."""
 
-    def __init__(self, api_key, account_type, save_file_folder, camera_entity, name):
+    def __init__(
+        self,
+        api_key,
+        account_type,
+        save_file_folder,
+        save_timestamped_file,
+        camera_entity,
+        name,
+    ):
         """Init."""
         super().__init__()
         self._api = hound.cloud(api_key, account_type)
@@ -84,16 +99,18 @@ class SighthoundEntity(ImageProcessingEntity):
         if name:
             self._name = name
         else:
-            camera_name = split_entity_id(camera_entity)[1]
-            self._name = "sighthound_{}".format(camera_name)
+            self._camera_name = split_entity_id(camera_entity)[1]
+            self._name = "sighthound_{}".format(self._camera_name)
         self._state = None
         self.faces = []
         self.people = []
         self._state = None
+        self._last_detection = None
         self._image_width = None
         self._image_height = None
         if save_file_folder:
             self._save_file_folder = save_file_folder
+        self._save_timestamped_file = save_timestamped_file
 
     def process_image(self, image):
         """Process an image."""
@@ -106,6 +123,8 @@ class SighthoundEntity(ImageProcessingEntity):
             self._image_height = metadata["image_height"]
 
             self._state = len(self.people)
+            if self._state > 0:
+                self._last_detection = dt_util.now().strftime(DATETIME_FORMAT)
             if hasattr(self, "_save_file_folder") and self._state > 0:
                 self.save_image(image, self.people, self.faces, self._save_file_folder)
             for face in self.faces:
@@ -150,6 +169,22 @@ class SighthoundEntity(ImageProcessingEntity):
 
         latest_save_path = directory + "{}_latest.jpg".format(self._name)
         img.save(latest_save_path)
+
+        if self._save_timestamped_file:
+            timestamp_save_path = directory + "{} {}.jpg".format(
+                self._name, self._last_detection
+            )
+
+            img.save(timestamp_save_path)
+            self.fire_saved_file_event(timestamp_save_path)
+            _LOGGER.info("Saved %s", timestamp_save_path)
+
+    def fire_saved_file_event(self, save_path):
+        """Fire event when saving a file"""
+        self.hass.bus.fire(
+            EVENT_FILE_SAVED,
+            {ATTR_ENTITY_ID: self.entity_id, CONF_FILE_PATH: save_path},
+        )
 
     def fire_person_detected_event(self, person):
         """Send event with detected total_persons."""
@@ -200,6 +235,9 @@ class SighthoundEntity(ImageProcessingEntity):
     @property
     def device_state_attributes(self):
         """Return the classifier attributes."""
-        return {
+        attr = {
             ATTR_FACES: len(self.faces),
         }
+        if self._last_detection:
+            attr["last_person"] = self._last_detection
+        return attr


### PR DESCRIPTION
Optionally save a timestamped image on each person detection. This allows the creation of a record of all detections, and simplifies sending notifications. Additionally the time of the last detection is exposed as an attribute.